### PR TITLE
Add metadata to report.json format, adjust parsing

### DIFF
--- a/download.js
+++ b/download.js
@@ -1,6 +1,5 @@
 // Downloading infrastructure.
 
-//
 var googleapis = require('googleapis'),
     ga = googleapis.analytics('v3'),
     url = require('url'),
@@ -27,11 +26,12 @@ var Analytics = {
     query: function(report, callback) {
 
         // insert IDs and auth data
-        report.ids = config.account.ids;
-        report.auth = jwt;
+        var query = report.query;
+        query.ids = config.account.ids;
+        query.auth = jwt;
 
         jwt.authorize(function(err, result) {
-            ga.data.ga.get(report, function(err, result) {
+            ga.data.ga.get(query, function(err, result) {
                 if (err) return callback(err, null);
                 // TODO: transform, then return transformed data
                 callback(null, result);

--- a/reports.json
+++ b/reports.json
@@ -1,12 +1,18 @@
-
 {
   "reports": [
     {
       "name": "weekly-users",
-      "dimensions": "ga:dayOfWeekName,ga:date",
-      "metrics": "ga:users",
-      "start-date" : "8daysAgo",
-      "end-date" : "yesterday"
+      "query": {
+        "dimensions": "ga:dayOfWeekName,ga:date",
+        "metrics": "ga:users",
+        "start-date" : "8daysAgo",
+        "end-date" : "yesterday"
+      },
+      "meta": {
+        "site": "all",
+        "description:": "Weekly visitors to all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
+        "documentation": "http://www.usa.gov/performance"
+      }
     }
   ]
 }


### PR DESCRIPTION
This makes report.json look like this:

```json
{
  "reports": [
    {
      "name": "weekly-users",
      "query": {
        "dimensions": "ga:dayOfWeekName,ga:date",
        "metrics": "ga:users",
        "start-date" : "8daysAgo",
        "end-date" : "yesterday"
      },
      "meta": {
        "site": "all",
        "description:": "Weekly visitors to all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
        "documentation": "http://www.usa.gov/performance"
      }
    }
  ]
}
```

So that we keep any data there we also want to potentially include in the data output. This PR doesn't handle changing the data output -- I'd like to give @ramirezg a chance to ring in on #9 first.