### PR TITLE
New output schema, simplify code flow

### DIFF
--- a/reports.json
+++ b/reports.json
@@ -3,9 +3,9 @@
     {
       "name": "weekly-users",
       "query": {
-        "dimensions": "ga:dayOfWeekName,ga:date",
+        "dimensions": "ga:date",
         "metrics": "ga:users",
-        "start-date" : "8daysAgo",
+        "start-date" : "7daysAgo",
         "end-date" : "yesterday"
       },
       "meta": {


### PR DESCRIPTION
This now outputs a `weekly-users.json` file that looks like this:

```javascript
{
  "name": "weekly-users",
  "query": {
    "dimensions": "ga:date",
    "metrics": "ga:users",
    "start-date": "7daysAgo",
    "end-date": "yesterday"
  },
  "meta": {
    "site": "all",
    "description:": "Weekly visitors to all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
    "documentation": "http://www.usa.gov/performance"
  },
  "data": [
    {
      "date": "2014-12-28",
      "visitors": "XXXXXXXXXX"
    },
    {
      "date": "2014-12-29",
      "visitors": "XXXXXXXXXXX"
    },
    // ...
  ],
  "totals": {
    "visitors": "YYYYYYYY",
    "start_date": "2014-12-28",
    "end_date": "2015-01-03"
  }
}
```

The output is similar to #9, but I added in the original GA query data, and moved the metadata into a `meta` field, like it is in `reports.json`.

I also simplified the overall code path, and adjusted the weekly users report to report 7 days instead of 8, and to flatten the data output directory (to not output the raw google analytics response to disk at all).

Fixes #9.