### PR TITLE
Executables that run report(s) and print to STDOUT or disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 .python-version
 /.env
+*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 *.p12
 *.pem
-/data
 /node_modules
 .python-version
 /.env

--- a/bin/all-reports
+++ b/bin/all-reports
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
 
 /*
- * Run all analytics reports output JSON to disk, current dir.
+ * Run all analytics reports output JSON to disk.
  *
  * Usage: all-reports
+ *
+ * --output: Change output directory. Defaults to CWD.
  */
 
 var Analytics = require("../download"),
     fs = require("fs");
 
 
-var run = function(dir, options) {
-  if (!dir) dir = ".";
+var run = function(options) {
   if (!options) options = {};
+  if (!options.output) options.output = ".";
 
   var names = Object.keys(Analytics.reports);
 
@@ -25,13 +27,11 @@ var run = function(dir, options) {
 
         console.log("[" + report.name + "] Saving report data...");
         var json = JSON.stringify(data, null, 2);
-        fs.writeFileSync(dir + "/" + report.name + ".json", json);
+        fs.writeFileSync(options.output + "/" + report.name + ".json", json);
 
         console.log("[" + report.name + "] Done.");
     });
   }
 };
 
-var options = require('minimist')(process.argv.slice(2));
-// console.log(options);
-run(options._[0], options);
+run(require('minimist')(process.argv.slice(2)));

--- a/bin/all-reports
+++ b/bin/all-reports
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+/*
+ * Run all analytics reports output JSON to disk, current dir.
+ *
+ * Usage: all-reports
+ */
+
+var Analytics = require("../download"),
+    fs = require("fs");
+
+
+var run = function(dir, options) {
+  if (!dir) dir = ".";
+  if (!options) options = {};
+
+  var names = Object.keys(Analytics.reports);
+
+  for (var i=0; i<names.length; i++) {
+    var report = Analytics.reports[names[i]];
+
+    console.log("\n[" + report.name + "] Fetching...");
+    Analytics.query(report, function(err, data) {
+        if (err) return console.log("ERROR: " + JSON.stringify(err));
+
+        console.log("[" + report.name + "] Saving report data...");
+        var json = JSON.stringify(data, null, 2);
+        fs.writeFileSync(dir + "/" + report.name + ".json", json);
+
+        console.log("[" + report.name + "] Done.");
+    });
+  }
+};
+
+var options = require('minimist')(process.argv.slice(2));
+// console.log(options);
+run(options._[0], options);

--- a/bin/report
+++ b/bin/report
@@ -18,7 +18,7 @@ var run = function(name, options) {
 
   if (!name || !Analytics.reports[name]) {
     var names = Object.keys(Analytics.reports);
-    console.log("Usage:\n\treport [name]\n\treport all\n\nAvailable reports: " + names.join(", "));
+    console.log("Usage: report [name]\n\nAvailable reports: " + names.join(", "));
     process.exit(1);
   }
 

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/*
+ * Run a given analytics report and generate JSON via STDOUT.
+ *
+ * Usage:
+ *   report [name]
+ *
+ * No option flags at this time.
+ *
+ * Where (for now) [name] is given in reports.json.
+ */
+
+var Analytics = require("../download");
+
+var run = function(name, options) {
+  if (!options) options = {};
+
+  if (!name || !Analytics.reports[name]) {
+    var names = Object.keys(Analytics.reports);
+    console.log("Usage:\n\treport [name]\n\treport all\n\nAvailable reports: " + names.join(", "));
+    process.exit(1);
+  }
+
+  var report = Analytics.reports[name];
+  Analytics.query(report, function(err, result) {
+    if (err) return process.exit(1);
+
+    console.log(JSON.stringify(result, null, 2));
+  });
+}
+
+var options = require('minimist')(process.argv.slice(2));
+// console.log(options);
+run(options._[0], options);

--- a/download.js
+++ b/download.js
@@ -58,10 +58,6 @@ var Analytics = {
         return [in_date.substr(0,4), in_date.substr(4, 2), in_date.substr(6, 2)].join("-")
     },
 
-    path: function(report) {
-        return "data/" + report.name + ".json";
-    },
-
     // Given a report and a raw google response, transform it into our schema.
     process: function(report, data) {
         var result = {
@@ -94,22 +90,3 @@ var Analytics = {
 };
 
 module.exports = Analytics;
-
-/*  Actually download the files. This should be separated from the above
-    modules at some point.
-*/
-
-// for (var i=0; i<reports.length; i++) {
-//     var report = reports[i];
-
-//     console.log("\n[" + report.name + "] Fetching...");
-//     Analytics.query(report, function(err, data) {
-//         if (err) return console.log("ERROR: " + JSON.stringify(err));
-
-//         console.log("[" + report.name + "] Saving report data...");
-//         var json = JSON.stringify(data, null, 2);
-//         fs.writeFileSync(Analytics.path(report), json);
-
-//         console.log("[" + report.name + "] Done.");
-//     });
-// }

--- a/download.js
+++ b/download.js
@@ -3,8 +3,7 @@
 var googleapis = require('googleapis'),
     ga = googleapis.analytics('v3'),
     url = require('url'),
-    fs = require('fs'),
-    mkdirp = require('mkdirp');
+    fs = require('fs');
 
 var models = require('./models'),
     config = require('./config');
@@ -18,10 +17,15 @@ var jwt = new googleapis.auth.JWT(
 
 // The reports we want to run.
 var reports = JSON.parse(fs.readFileSync("./reports.json")).reports;
+var by_name = {};
+for (var i=0; i<reports.length; i++)
+    by_name[reports[i].name] = reports[i];
 
 // Google Analytics data fetching and transformation utilities.
 // This should really move to its own analytics.js file.
 var Analytics = {
+
+    reports: by_name,
 
     query: function(report, callback) {
 
@@ -40,9 +44,18 @@ var Analytics = {
             if (err) return callback(err, null);
             ga.data.ga.get(query, function(err, result) {
                 if (err) return callback(err, null);
+
+                // debug: write google output to disk
+                // fs.writeFileSync("data/google/" + report.name + ".json", JSON.stringify(result, null, 2));
+
                 callback(null, Analytics.process(report, result));
             });
         });
+    },
+
+    // translate 20141228 -> 2014-12-28
+    date_format: function(in_date) {
+        return [in_date.substr(0,4), in_date.substr(4, 2), in_date.substr(6, 2)].join("-")
     },
 
     path: function(report) {
@@ -64,7 +77,7 @@ var Analytics = {
             var row = data.rows[i];
 
             result.data.push({
-                date: row[0],
+                date: Analytics.date_format(row[0]),
                 visitors: row[1]
             });
         }
@@ -72,8 +85,8 @@ var Analytics = {
         // calculate totals
         result.totals.visitors = data.totalsForAllResults["ga:users"]
         // ga:date should always be the first dimension
-        result.totals.start_date = data.rows[0][0];
-        result.totals.end_date = data.rows[data.rows.length-1][0];
+        result.totals.start_date = Analytics.date_format(data.rows[0][0]);
+        result.totals.end_date = Analytics.date_format(data.rows[data.rows.length-1][0]);
 
         return result;
     }
@@ -86,17 +99,17 @@ module.exports = Analytics;
     modules at some point.
 */
 
-for (var i=0; i<reports.length; i++) {
-    var report = reports[i];
+// for (var i=0; i<reports.length; i++) {
+//     var report = reports[i];
 
-    console.log("\n[" + report.name + "] Fetching...");
-    Analytics.query(report, function(err, data) {
-        if (err) return console.log("ERROR: " + JSON.stringify(err));
+//     console.log("\n[" + report.name + "] Fetching...");
+//     Analytics.query(report, function(err, data) {
+//         if (err) return console.log("ERROR: " + JSON.stringify(err));
 
-        console.log("[" + report.name + "] Saving report data...");
-        var json = JSON.stringify(data, null, 2);
-        fs.writeFileSync(Analytics.path(report), json);
+//         console.log("[" + report.name + "] Saving report data...");
+//         var json = JSON.stringify(data, null, 2);
+//         fs.writeFileSync(Analytics.path(report), json);
 
-        console.log("[" + report.name + "] Done.");
-    });
-}
+//         console.log("[" + report.name + "] Done.");
+//     });
+// }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "scripts": {
     "start": "node app.js"
   },
+  "bin": {
+    "report": "./bin/report"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/18f/analytics-proxy-nodejs.git"
@@ -20,6 +23,7 @@
     "googleapis": "^1.0.21",
     "mongoose": "^3.8.19",
     "node-schedule": "^0.1.13",
-    "mkdirp": "*"
+    "mkdirp": "*",
+    "minimist": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "start": "node app.js"
   },
   "bin": {
-    "report": "./bin/report"
+    "report": "./bin/report",
+    "all-reports": "./bin/all-reports"
   },
   "repository": {
     "type": "git",

--- a/reports.json
+++ b/reports.json
@@ -3,9 +3,9 @@
     {
       "name": "weekly-users",
       "query": {
-        "dimensions": "ga:dayOfWeekName,ga:date",
+        "dimensions": "ga:date",
         "metrics": "ga:users",
-        "start-date" : "8daysAgo",
+        "start-date" : "7daysAgo",
         "end-date" : "yesterday"
       },
       "meta": {


### PR DESCRIPTION
This adds a `bin/report` script that loads in the Analytics module in `download.js` and uses it to run individual reports. Without any arguments:

```bash
$ ./bin/report
Usage: report [name]

Available reports: weekly-users
```

With a report name:

```bash
$ ./bin/report weekly-users
{
  "name": "weekly-users",
  "query": {
    "dimensions": "ga:date",
    "metrics": "ga:users",
    "start-date": "7daysAgo",
    "end-date": "yesterday"
  },
 ...
```

This also adds an `Analytics.reports` object that has reports indexed by name, so you can ask for `Analytics.reports['weekly-visitors']`, instead of iterating through a list to find the report with the right `name` field.

Downstream from #20. Fixes #12.