### PR TITLE
New reports

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -79,7 +79,9 @@ var Analytics = {
         "ga:deviceCategory": "device",
         "ga:operatingSystem": "os",
         "ga:operatingSystemVersion": "os_version",
-        "ga:hostname": "domain"
+        "ga:hostname": "domain",
+        "ga:browser" : 'browser',
+        "ga:browserVersion" : "browser_version"
     },
 
     // The OSes we care about for the OS breakdown. The rest can be "Other".
@@ -94,6 +96,15 @@ var Analytics = {
     windows_versions: [
         "XP", "Vista", "7", "8", "8.1"
     ],
+
+    // The browsers we care about for the browser report. The rest are "Other"
+    //  These are the exact strings used by Google Analytics.
+    browsers: [
+        "Internet Explorer", "Chrome", "Safari", "Firefox", "Android Browser",
+        "Safari (in-app)", "Amazon Silk", "Opera", "Opera Mini",
+        "IE with Chrome Frame", "BlackBerry", "UC Browser"
+    ],
+
 
     // Given a report and a raw google response, transform it into our schema.
     process: function(report, data) {
@@ -175,6 +186,32 @@ var Analytics = {
                     version = "Other";
 
                 result.totals.os_version[version] += parseInt(result.data[i].visits);
+            }
+        }
+
+        if (report.name == "browsers") {
+
+            result.totals.browser = {};
+            for (var i=0; i<Analytics.browsers.length; i++)
+                result.totals.browser[Analytics.browsers[i]] = 0;
+            result.totals.browser["Other"] = 0;
+
+            for (var i=0; i<result.data.length; i++) {
+                var browser = result.data[i].browser;
+
+                if (Analytics.browsers.indexOf(browser) < 0)
+                    browser = "Other";
+
+                result.totals.browser[browser] += parseInt(result.data[i].visits);
+            }
+        }
+
+        if (report.name == "ie-version") {
+
+            result.totals.browser_version = {};
+            for (var i=0; i<result.data.length; i++) {
+                var version = result.data[i].browser_version
+                result.totals.browser_version[version] = parseInt(result.data[i].visits);
             }
         }
 

--- a/reports.json
+++ b/reports.json
@@ -111,12 +111,42 @@
         "start-date": "7daysAgo",
         "end-date": "yesterday",
         "sort": "-ga:sessions",
-        "max-results": "20"
+        "max-results": "50"
       },
       "meta": {
-        "description": "Breakdown of top 20 sources in terms of sessions for the last week",
+        "description": "Breakdown of top 50 sources in terms of sessions for the last week",
+        "documentation": "http://www.usa.gov/performance"
+      }
+    },
+    {
+      "name": "browsers",
+      "query": {
+        "dimensions": ["ga:date" ,"ga:browser"],
+        "metrics": ["ga:sessions"],
+        "start-date": "7daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions"
+      },
+      "meta": {
+        "description": "Weekly visits by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
+        "documentation": "http://www.usa.gov/performance"
+      }
+    },
+    {
+      "name": "ie-version",
+      "query": {
+        "dimensions": ["ga:date","ga:browser","ga:browserVersion"],
+        "metrics": ["ga:sessions"],
+        "start-date": "7daysAgo",
+        "end-date": "yesterday",
+        "sort": "ga:date,-ga:sessions",
+        "filters": ["ga:browser==Internet Explorer"]
+      },
+      "meta": {
+        "description": "Weekly visits by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
     }
+
   ]
 }

--- a/reports.json
+++ b/reports.json
@@ -128,7 +128,7 @@
         "sort": "ga:date,-ga:sessions"
       },
       "meta": {
-        "description": "Weekly visits by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
+        "description": "Weekly visits broken down by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
     },
@@ -143,7 +143,7 @@
         "filters": ["ga:browser==Internet Explorer"]
       },
       "meta": {
-        "description": "Weekly visits by browser for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
+        "description": "Weekly visits from Internet Explorer users broken down by version for all .gov sites tracked by the U.S. federal government's Digital Analytics Program.",
         "documentation": "http://www.usa.gov/performance"
       }
     }


### PR DESCRIPTION
Adding browsers and ie-version reports. 

I'm not sure I like collecting data on all browsers and totaling a set number. Should we only collect data on browsers with over 1000 views?

For IE versions, I didn't limit them to a set because there are so few. 