### PR TITLE
Proposal: rename repo to analytics-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.10

--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ You may wish to manage these using [`autoenv`](https://github.com/kennethreitz/a
 
 If you see a nicely formatted JSON file, you are all set.
 
+* (Optional) Authorize yourself for S3 publishing.
+
+If you plan to use this project's lightweight S3 publishing system, you'll need to add 6 more environment variables:
+
+```
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=[your-key]
+export AWS_SECRET_ACCESS_KEY=[your-secret-key]
+
+export AWS_BUCKET=[your-bucket]
+export AWS_BUCKET_PATH=[your-path]
+export AWS_CACHE_TIME=0
+```
+
 ### Use
 
 Reports are named and described in [`reports.json`](reports.json). You can publish reports in 2 ways:
@@ -77,6 +91,26 @@ It should print something like:
 ```
 
 It will drop a copy of every report (`users.json`, `devices.json`, etc.) to disk in the current working directory. Override the output directory with the `--output` flag.
+
+Use the `--only` flag to limit this to a single report:
+
+```bash
+./bin/all-reports --only devices
+```
+
+* **Publish every report to S3** by adding `--publish` to `all-reports`:
+
+```bash
+./bin/all-reports --publish
+```
+
+This will put a copy of every report into S3, at the bucket and path you've specified in your environment variables.
+
+You can also limit this to a single report:
+
+```bash
+./bin/all-reports --publish --only devices
+```
 
 ### Public domain
 

--- a/bin/all-reports
+++ b/bin/all-reports
@@ -29,7 +29,7 @@ var publish = function(name, json, callback) {
     Body: json,
     ContentType: "application/json",
     ACL: "public-read",
-    CacheControl: "max-age=" + (config.aws.cache || 3600)
+    CacheControl: "max-age=" + (config.aws.cache || 0)
   }, callback);
 };
 

--- a/bin/all-reports
+++ b/bin/all-reports
@@ -6,18 +6,40 @@
  * Usage: all-reports
  *
  * --output: Change output directory. Defaults to CWD.
+ * --publish: Instead of writing to disk, publish to an S3 bucket.
+ * --only: only run one report.
  */
 
 var Analytics = require("../analytics"),
+    config = require("../config"),
     fs = require("fs"),
     async = require("async");
+
+
+// AWS credentials are looked for in env vars or in ~/.aws/config.
+// AWS bucket and path need to be set in env vars mentioned in config.js.
+
+var AWS = require("aws-sdk");
+
+var publish = function(name, json, callback) {
+  console.log("[" + name + "] Publishing to " + config.aws.bucket + "...");
+
+  new AWS.S3({params: {Bucket: config.aws.bucket}}).upload({
+    Key: config.aws.path + "/" + name + ".json",
+    Body: json,
+    ContentType: "application/json",
+    ACL: "public-read",
+    CacheControl: "max-age=" + (config.aws.cache || 3600)
+  }, callback);
+};
 
 
 var run = function(options) {
   if (!options) options = {};
   if (!options.output) options.output = ".";
 
-  var names = Object.keys(Analytics.reports);
+  // can be overridden to only do one report
+  var names = options.only ? [options.only] : Object.keys(Analytics.reports);
 
   var eachReport = function(name, done) {
     var report = Analytics.reports[name];
@@ -28,10 +50,19 @@ var run = function(options) {
 
         console.log("[" + report.name + "] Saving report data...");
         var json = JSON.stringify(data, null, 2);
-        fs.writeFileSync(options.output + "/" + report.name + ".json", json);
 
-        console.log("[" + report.name + "] Done.");
-        done();
+        var written = function(err) {
+          if (err)
+            console.error("ERROR: " + JSON.stringify(err));
+          else
+            console.log("[" + report.name + "] Done.");
+          done();
+        };
+
+        if (options.publish)
+          publish(report.name, json, written);
+        else
+          fs.writeFile(options.output + "/" + report.name + ".json", json, written);
     });
   };
 

--- a/config.js
+++ b/config.js
@@ -7,6 +7,14 @@ module.exports = {
 
   debug: (process.env.ANALYTICS_DEBUG ? true : false),
 
+  // No trailing slashes
+  aws: {
+    bucket: process.env.AWS_BUCKET,
+    path: process.env.AWS_BUCKET_PATH,
+    // in seconds. Defaults to an hour (3600)
+    cache: process.env.AWS_CACHE_TIME
+  },
+
   account: {
     ids: process.env.ANALYTICS_REPORT_IDS
   },

--- a/config.js
+++ b/config.js
@@ -7,8 +7,14 @@ module.exports = {
 
   debug: (process.env.ANALYTICS_DEBUG ? true : false),
 
-  // No trailing slashes
+  /*
+    AWS S3 information.
+
+    Separately, you need to set AWS_REGION, AWS_ACCESS_KEY_ID, and
+    AWS_SECRET_ACCESS_KEY. The AWS SDK for Node reads these in automatically.
+  */
   aws: {
+    // No trailing slashes
     bucket: process.env.AWS_BUCKET,
     path: process.env.AWS_BUCKET_PATH,
     // HTTP cache time in seconds. Defaults to 0.

--- a/config.js
+++ b/config.js
@@ -11,7 +11,7 @@ module.exports = {
   aws: {
     bucket: process.env.AWS_BUCKET,
     path: process.env.AWS_BUCKET_PATH,
-    // in seconds. Defaults to an hour (3600)
+    // HTTP cache time in seconds. Defaults to 0.
     cache: process.env.AWS_CACHE_TIME
   },
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "18f_analytics_proxy",
+  "name": "analytics-reporter",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -12,12 +12,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/18f/analytics-proxy-nodejs.git"
+    "url": "git://github.com/18f/analytics-reporter.git"
   },
   "bugs": {
-    "url": "https://github.com/18f/analytics-proxy-nodejs/issues"
+    "url": "https://github.com/18f/analytics-reporter/issues"
   },
-  "homepage": "https://github.com/18f/analytics-proxy-nodejs",
+  "homepage": "https://github.com/18f/analytics-reporter",
   "license": "CC0",
   "dependencies": {
     "body-parser": "~1.8.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "node test/*"
   },
   "bin": {
     "report": "./bin/report",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mongoose": "^3.8.19",
     "node-schedule": "^0.1.13",
     "minimist": "*",
-    "async": "*"
+    "async": "*",
+    "aws-sdk": "*"
   }
 }

--- a/test/sanity.js
+++ b/test/sanity.js
@@ -1,0 +1,6 @@
+
+// make sure analytics.js is free of syntax errors
+require("../analytics");
+
+// one test case beyond that
+require('assert').ok( 1, 'sanity' );


### PR DESCRIPTION
This PR updates `package.json` to expect a repo and package renamed to `analytics-reporter`.

Any objections? Very much open to other suggestions. It'd be nice to have one which is not taken on npm. `analytics-reporter` is currently [still available](https://www.npmjs.com/analytics-reporter).

Downstream of #39. Fixes #16.